### PR TITLE
Add clickable button to filter issues and PRs

### DIFF
--- a/src/app/core/models/github/github-graphql.issue-or-pr.ts
+++ b/src/app/core/models/github/github-graphql.issue-or-pr.ts
@@ -17,7 +17,7 @@ export class GithubGraphqlIssueOrPr extends GithubIssue {
         state: model.state,
         stateReason: null,
         user: {
-          login: model.author.login
+          login: model.author?.login || 'ghost'
         },
         assignees: flattenEdges(model.assignees.edges),
         labels: flattenEdges(model.labels.edges),
@@ -40,7 +40,7 @@ export class GithubGraphqlIssueOrPr extends GithubIssue {
         state: model.state,
         stateReason: model.stateReason,
         user: {
-          login: model.author.login
+          login: model.author?.login || 'ghost'
         },
         assignees: flattenEdges(model.assignees.edges),
         labels: flattenEdges(model.labels.edges),

--- a/src/app/core/models/github/github-graphql.issue.ts
+++ b/src/app/core/models/github/github-graphql.issue.ts
@@ -15,7 +15,7 @@ export class GithubGraphqlIssue extends GithubIssue {
       state: issue.state,
       stateReason: issue.stateReason,
       user: {
-        login: issue.author.login
+        login: issue.author?.login || 'ghost'
       },
       assignees: flattenEdges(issue.assignees.edges),
       labels: flattenEdges(issue.labels.edges),

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -181,6 +181,11 @@ div.column-header .mat-card-header {
   color: white;
 }
 
+.issue-row-count.inactive,
+.pr-row-count.inactive {
+  background-color: rgb(222, 222, 222);
+}
+
 .assignee-container {
   width: 100%;
   text-align: left;

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -131,32 +131,7 @@ div.column-header .mat-card-header {
   margin: 6px 0;
 }
 
-.row-count {
-  background-color: rgb(222, 222, 222);
-  border-radius: 3px;
-  cursor: default;
-  padding: 6px 8px 3px 8px;
-  color: rgb(0, 0, 0);
-  font-weight: 410;
-  display: inline-flex;
-  font-size: 14px;
-  flex-shrink: 0;
-  margin-top: 3px;
-}
-
-.issue-row-count {
-  background-color: rgb(222, 222, 222);
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 6px 8px 3px 8px;
-  color: rgb(0, 0, 0);
-  font-weight: 410;
-  display: inline-flex;
-  font-size: 14px;
-  flex-shrink: 0;
-  margin-top: 3px;
-}
-
+.issue-row-count,
 .pr-row-count {
   background-color: rgb(222, 222, 222);
   border-radius: 3px;
@@ -168,6 +143,7 @@ div.column-header .mat-card-header {
   font-size: 14px;
   flex-shrink: 0;
   margin-top: 3px;
+  user-select: none;
 }
 
 .issue-row-count:hover,
@@ -177,8 +153,7 @@ div.column-header .mat-card-header {
 
 .issue-row-count.active,
 .pr-row-count.active {
-  background-color: rgb(100, 149, 237);
-  color: white;
+  background-color: #b8b8b8;
 }
 
 .issue-row-count.inactive,

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -144,6 +144,43 @@ div.column-header .mat-card-header {
   margin-top: 3px;
 }
 
+.issue-row-count {
+  background-color: rgb(222, 222, 222);
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 6px 8px 3px 8px;
+  color: rgb(0, 0, 0);
+  font-weight: 410;
+  display: inline-flex;
+  font-size: 14px;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+.pr-row-count {
+  background-color: rgb(222, 222, 222);
+  border-radius: 3px;
+  cursor: pointer;
+  padding: 6px 8px 3px 8px;
+  color: rgb(0, 0, 0);
+  font-weight: 410;
+  display: inline-flex;
+  font-size: 14px;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+.issue-row-count:hover,
+.pr-row-count:hover {
+  background-color: rgb(200, 200, 200);
+}
+
+.issue-row-count.active,
+.pr-row-count.active {
+  background-color: rgb(100, 149, 237);
+  color: white;
+}
+
 .assignee-container {
   width: 100%;
   text-align: left;

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -6,8 +6,7 @@
   <div class="scrollable-container-wrapper scroll-shadow">
     <div class="scrollable-container">
       <div class="issue-pr-cards" *ngFor="let issue of this.issues$ | async; index as i">
-        <app-issue-pr-card *ngIf="isIssueCard(issue)" [issue]="issue" [filter]="issues.filter" [milestoneService]="milestoneService">
-        </app-issue-pr-card>
+        <app-issue-pr-card [issue]="issue" [filter]="issues.filter" [milestoneService]="milestoneService"> </app-issue-pr-card>
       </div>
       <mat-card class="loading-spinner" *ngIf="this.issues.isLoading$ | async">
         <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -43,7 +43,7 @@
         <mat-card-title>
           <div class="assignee-container">
             <div
-              class="assignee-name"
+              class="assignee-name no-select"
               (click)="goToGithubProfile(assignee.login)"
               [ngClass]="{ clickable: assignee.login !== 'Unassigned' }"
             >
@@ -61,7 +61,7 @@
               [style.cursor]="this.issues.hasIssue ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="issue-opened"></span>
-              <span class="">{{ this.issues.issueCount }}</span>
+              <span class="no-select">{{ this.issues.issueCount }}</span>
             </div>
             <div
               class="pr-row-count"
@@ -73,7 +73,7 @@
               [style.cursor]="this.issues.hasPR ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="git-pull-request"></span>
-              <span>{{ this.issues.prCount }}</span>
+              <span class="no-select">{{ this.issues.prCount }}</span>
             </div>
           </div>
         </mat-card-title>
@@ -88,7 +88,7 @@
       <mat-card-header [ngStyle]="{ height: '40px' }">
         <mat-card-title>
           <div class="milestone-container">
-            <div>
+            <div class="no-select">
               {{ milestone.title }}
             </div>
             <div
@@ -101,7 +101,7 @@
               [style.cursor]="this.issues.hasIssue ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="issue-opened"></span>
-              <span class="">{{ this.issues.issueCount }}</span>
+              <span class="no-select">{{ this.issues.issueCount }}</span>
             </div>
             <div
               class="pr-row-count"
@@ -113,7 +113,7 @@
               [style.cursor]="this.issues.hasPR ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="git-pull-request"></span>
-              <span>{{ this.issues.prCount }}</span>
+              <span class="no-select">{{ this.issues.prCount }}</span>
             </div>
           </div>
         </mat-card-title>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -6,7 +6,8 @@
   <div class="scrollable-container-wrapper scroll-shadow">
     <div class="scrollable-container">
       <div class="issue-pr-cards" *ngFor="let issue of this.issues$ | async; index as i">
-        <app-issue-pr-card [issue]="issue" [filter]="issues.filter" [milestoneService]="milestoneService"></app-issue-pr-card>
+        <app-issue-pr-card *ngIf="isIssueCard(issue)" [issue]="issue" [filter]="issues.filter" [milestoneService]="milestoneService">
+        </app-issue-pr-card>
       </div>
       <mat-card class="loading-spinner" *ngIf="this.issues.isLoading$ | async">
         <mat-progress-spinner color="primary" mode="indeterminate" diameter="50" strokeWidth="5"></mat-progress-spinner>
@@ -45,11 +46,25 @@
             <div class="assignee-name">
               {{ assignee.login }}
             </div>
-            <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">
+            <div
+              class="issue-row-count count-margins"
+              [matTooltip]="getIssueTooltip()"
+              matTooltipPosition="above"
+              (click)="filterByIssues()"
+              [class.active]="currentFilter === 'issues'"
+              style="cursor: pointer"
+            >
               <span class="octicon count-margins" octicon="issue-opened"></span>
               <span class="">{{ this.issues.issueCount }}</span>
             </div>
-            <div class="row-count" [matTooltip]="getPrTooltip()" matTooltipPosition="above">
+            <div
+              class="pr-row-count"
+              [matTooltip]="getPrTooltip()"
+              matTooltipPosition="above"
+              (click)="filterByPrs()"
+              [class.active]="currentFilter === 'prs'"
+              style="cursor: pointer"
+            >
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
             </div>
@@ -69,11 +84,25 @@
             <div>
               {{ milestone.title }}
             </div>
-            <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">
+            <div
+              class="issue-row-count count-margins"
+              [matTooltip]="getIssueTooltip()"
+              matTooltipPosition="above"
+              (click)="filterByIssues()"
+              [class.active]="currentFilter === 'issues'"
+              style="cursor: pointer"
+            >
               <span class="octicon count-margins" octicon="issue-opened"></span>
               <span class="">{{ this.issues.issueCount }}</span>
             </div>
-            <div class="row-count" [matTooltip]="getPrTooltip()" matTooltipPosition="above">
+            <div
+              class="pr-row-count"
+              [matTooltip]="getPrTooltip()"
+              matTooltipPosition="above"
+              (click)="filterByPrs()"
+              [class.active]="currentFilter === 'prs'"
+              style="cursor: pointer"
+            >
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
             </div>

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -47,22 +47,24 @@
             </div>
             <div
               class="issue-row-count count-margins"
+              [class.inactive]="!this.issues.hasIssue"
               [matTooltip]="getIssueTooltip()"
               matTooltipPosition="above"
-              (click)="filterByIssues()"
+              (click)="this.issues.hasIssue && filterByIssues()"
               [class.active]="currentFilter === 'issues'"
-              style="cursor: pointer"
+              [style.cursor]="this.issues.hasIssue ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="issue-opened"></span>
               <span class="">{{ this.issues.issueCount }}</span>
             </div>
             <div
               class="pr-row-count"
+              [class.inactive]="!this.issues.hasPR"
               [matTooltip]="getPrTooltip()"
               matTooltipPosition="above"
-              (click)="filterByPrs()"
+              (click)="this.issues.hasPR && filterByPrs()"
               [class.active]="currentFilter === 'prs'"
-              style="cursor: pointer"
+              [style.cursor]="this.issues.hasPR ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>
@@ -85,22 +87,24 @@
             </div>
             <div
               class="issue-row-count count-margins"
+              [class.inactive]="!this.issues.hasIssue"
               [matTooltip]="getIssueTooltip()"
               matTooltipPosition="above"
-              (click)="filterByIssues()"
+              (click)="this.issues.hasIssue && filterByIssues()"
               [class.active]="currentFilter === 'issues'"
-              style="cursor: pointer"
+              [style.cursor]="this.issues.hasIssue ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="issue-opened"></span>
               <span class="">{{ this.issues.issueCount }}</span>
             </div>
             <div
               class="pr-row-count"
+              [class.inactive]="!this.issues.hasPR"
               [matTooltip]="getPrTooltip()"
               matTooltipPosition="above"
-              (click)="filterByPrs()"
+              (click)="this.issues.hasPR && filterByPrs()"
               [class.active]="currentFilter === 'prs'"
-              style="cursor: pointer"
+              [style.cursor]="this.issues.hasPR ? 'pointer' : 'default'"
             >
               <span class="octicon count-margins" octicon="git-pull-request"></span>
               <span>{{ this.issues.prCount }}</span>

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -158,6 +158,7 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
     const issueFilter = this.currentFilter === 'prs' ? 'all' : 'prs';
     this.currentFilter = issueFilter;
     this.issues.setIssueTypeFilter(issueFilter);
+  }
 
   getAssigneeTooltip(assignee: any): string {
     return assignee.login;

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -53,6 +53,8 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   isLoading = true;
   issueLength = 0;
 
+  currentFilter: 'all' | 'issues' | 'prs' = 'all';
+
   pageSize = 20;
 
   @Output() issueLengthChange: EventEmitter<Number> = new EventEmitter<Number>();
@@ -144,5 +146,24 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
 
   getPrTooltip(): string {
     return this.issues.prCount + ' Pull Requests';
+  }
+
+  filterByIssues(): void {
+    this.currentFilter = this.currentFilter === 'issues' ? 'all' : 'issues';
+  }
+
+  filterByPrs(): void {
+    this.currentFilter = this.currentFilter === 'prs' ? 'all' : 'prs';
+  }
+
+  isIssueCard(issue: Issue): boolean {
+    switch (this.currentFilter) {
+      case 'issues':
+        return issue.issueOrPr === 'Issue';
+      case 'prs':
+        return issue.issueOrPr === 'PullRequest';
+      default:
+        return true;
+    }
   }
 }

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -149,21 +149,14 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   }
 
   filterByIssues(): void {
-    this.currentFilter = this.currentFilter === 'issues' ? 'all' : 'issues';
+    const issueFilter = this.currentFilter === 'issues' ? 'all' : 'issues';
+    this.currentFilter = issueFilter;
+    this.issues.setIssueTypeFilter(issueFilter);
   }
 
   filterByPrs(): void {
-    this.currentFilter = this.currentFilter === 'prs' ? 'all' : 'prs';
-  }
-
-  isIssueCard(issue: Issue): boolean {
-    switch (this.currentFilter) {
-      case 'issues':
-        return issue.issueOrPr === 'Issue';
-      case 'prs':
-        return issue.issueOrPr === 'PullRequest';
-      default:
-        return true;
-    }
+    const issueFilter = this.currentFilter === 'prs' ? 'all' : 'prs';
+    this.currentFilter = issueFilter;
+    this.issues.setIssueTypeFilter(issueFilter);
   }
 }

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.html
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="card" [ngClass]="getIssueOpenOrCloseColorCSSClass()">
+<mat-card class="card" [class.issue-card]="isIssue()" [ngClass]="getIssueOpenOrCloseColorCSSClass()">
   <a class="no-underline link-grey-dark">
     <span [matTooltip]="this.issue.updated_at">
       <app-issue-pr-card-header [issue]="issue" (click)="viewIssueInBrowser($event)"></app-issue-pr-card-header>

--- a/src/app/shared/issue-pr-card/issue-pr-card.component.ts
+++ b/src/app/shared/issue-pr-card/issue-pr-card.component.ts
@@ -22,6 +22,10 @@ export class IssuePrCardComponent {
     public milestoneService: MilestoneService
   ) {}
 
+  isIssue(): boolean {
+    return this.issue.issueOrPr === 'Issue';
+  }
+
   isNotFollowingForkingWorkflow() {
     return (
       this.issue.issueOrPr === 'PullRequest' && this.issue.headRepository?.toLowerCase() === this.githubService.getRepoURL().toLowerCase()

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -21,10 +21,12 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
   public count = 0;
   public issueCount = 0;
   public prCount = 0;
+  public hasIssue = false;
+  public hasPR = false;
   private filterChange = new BehaviorSubject(this.filtersService.defaultFilter);
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
-  private issueTypeFilter: 'all' | 'issues' | 'prs' = 'all';
+  private issueTypeFilter: 'all' | 'issues' | 'prs' = 'all'; // initialise as 'all'
 
   public isLoading$ = this.issueService.isLoading.asObservable();
 
@@ -111,16 +113,25 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
 
           this.issueCount = data.filter((issue) => issue.issueOrPr !== 'PullRequest').length;
           this.prCount = data.filter((issue) => issue.issueOrPr === 'PullRequest').length;
+          this.hasIssue = this.issueCount > 0;
+          this.hasPR = this.prCount > 0;
 
           // Apply Issue Type Filter for header component
           switch (this.issueTypeFilter) {
             case 'issues':
               data = data.filter((issue) => issue.issueOrPr === 'Issue');
+              if (data.length === 0) {
+                this.issueTypeFilter = 'all'; // Reset to 'all' if no issues found
+              }
               break;
             case 'prs':
               data = data.filter((issue) => issue.issueOrPr === 'PullRequest');
+              if (data.length === 0) {
+                this.issueTypeFilter = 'all'; // Reset to 'all' if no PRs found
+              }
               break;
             default:
+              this.issueTypeFilter = 'all';
               break;
           }
 

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -121,7 +121,11 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
             const issueType = this.issueTypeFilter === 'issues' ? 'Issue' : 'PullRequest';
             const filteredData = data.filter((issue) => issue.issueOrPr === issueType);
 
-            data = filteredData;
+            if (filteredData.length === 0) {
+              this.issueTypeFilter = 'all';
+            } else {
+              data = filteredData;
+            }
           }
 
           this.count = data.length;

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -24,6 +24,7 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
   private filterChange = new BehaviorSubject(this.filtersService.defaultFilter);
   private issuesSubject = new BehaviorSubject<Issue[]>([]);
   private issueSubscription: Subscription;
+  private issueTypeFilter: 'all' | 'issues' | 'prs' = 'all';
 
   public isLoading$ = this.issueService.isLoading.asObservable();
 
@@ -69,6 +70,15 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
     this.issueService.stopPollIssues();
   }
 
+  setIssueTypeFilter(filter: 'all' | 'issues' | 'prs') {
+    this.issueTypeFilter = filter;
+    this.loadIssues();
+  }
+
+  getIssueTypeFilter(): 'all' | 'issues' | 'prs' {
+    return this.issueTypeFilter;
+  }
+
   loadIssues() {
     let page;
     if (this.paginator !== undefined) {
@@ -98,8 +108,22 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
           data = applyDropdownFilter(this.filter, data, !this.milestoneService.hasNoMilestones, !this.assigneeService.hasNoAssignees);
 
           data = applySearchFilter(this.filter.title, this.displayedColumn, this.issueService, data);
+
           this.issueCount = data.filter((issue) => issue.issueOrPr !== 'PullRequest').length;
           this.prCount = data.filter((issue) => issue.issueOrPr === 'PullRequest').length;
+
+          // Apply Issue Type Filter for header component
+          switch (this.issueTypeFilter) {
+            case 'issues':
+              data = data.filter((issue) => issue.issueOrPr === 'Issue');
+              break;
+            case 'prs':
+              data = data.filter((issue) => issue.issueOrPr === 'PullRequest');
+              break;
+            default:
+              break;
+          }
+
           this.count = data.length;
 
           data = applySort(this.filter.sort, data);

--- a/src/app/shared/issue-tables/IssuesDataTable.ts
+++ b/src/app/shared/issue-tables/IssuesDataTable.ts
@@ -117,22 +117,11 @@ export class IssuesDataTable extends DataSource<Issue> implements FilterableSour
           this.hasPR = this.prCount > 0;
 
           // Apply Issue Type Filter for header component
-          switch (this.issueTypeFilter) {
-            case 'issues':
-              data = data.filter((issue) => issue.issueOrPr === 'Issue');
-              if (data.length === 0) {
-                this.issueTypeFilter = 'all'; // Reset to 'all' if no issues found
-              }
-              break;
-            case 'prs':
-              data = data.filter((issue) => issue.issueOrPr === 'PullRequest');
-              if (data.length === 0) {
-                this.issueTypeFilter = 'all'; // Reset to 'all' if no PRs found
-              }
-              break;
-            default:
-              this.issueTypeFilter = 'all';
-              break;
+          if (this.issueTypeFilter !== 'all') {
+            const issueType = this.issueTypeFilter === 'issues' ? 'Issue' : 'PullRequest';
+            const filteredData = data.filter((issue) => issue.issueOrPr === issueType);
+
+            data = filteredData;
           }
 
           this.count = data.length;


### PR DESCRIPTION
### Summary:

Add clickable header buttons for issues and PRs. This allows for unrestricted account-based filtering of issues/PRs, while also improving usability by reducing the number of clicks and mouse movements needed for filtering.

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Added issue type filtering logic instead of leveraging on the existing filter to prevent introducing bugs to the original state filter.
- Issues or PRs with a count of 0 will **not be allowed** to be filtered.
- Added hover state, active state, inactive state CSS styling to the buttons

### Screenshots:

<h3> Before </h3>

To look at only one type of card, you would need to go into status and tick/untick the respective boxes.

https://github.com/user-attachments/assets/b0e6d743-591d-43d2-8c12-c2c2ce8e2827

<h3> After </h3>

Now, you can just click to see whichever type of card on each user.
Note: this will be able to work alongside the original status filter.

https://github.com/user-attachments/assets/6de361b8-598e-499d-8952-9b31b204ea90


### Proposed Commit Message:

```
Adds the ability for users to filter cards by type (issue or PR) 
directly from the card view headers.

Clicking the issue or PR count toggles a filter to show only 
items of that type. Clicking the active filter again reverts this 
filter back to the original state.

This enhancement provides a more responsive, one-click method 
for filtering, which is especially useful in high-volume scenarios 
such as the huge influx of issues during PE-D or actual PE.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
