### PR TITLE
Show pagination across all user cards

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -169,35 +169,23 @@ div.column-header .mat-card-header {
 
 :host ::ng-deep .mat-paginator-container {
   display: flex;
-  min-height: 56px;
   align-items: center;
+  justify-content: flex-end;
   padding: 0 8px;
   flex-wrap: wrap-reverse;
   width: 100%;
-  position: relative;
 }
 
-:host ::ng-deep .mat-paginator-range-label {
-  position: static;
-  left: 50%;
-  transform: translateX(-50%);
-  margin: 0;
-  flex: none;
-  display: block !important;
+.mat-paginator-range-label {
+  margin: 0 32px 0 24px;
 }
 
-:host ::ng-deep .mat-paginator-range-actions {
-  margin-left: auto;
-  display: flex !important;
+.mat-paginator-range-actions {
+  display: flex;
+  align-items: center;
 }
 
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous,
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-next {
-  visibility: hidden !important;
-}
-
-:host ::ng-deep .pagination-hide-arrow .mat-paginator-range-actions {
-  display: flex !important;
-  justify-content: flex-end;
-  width: auto;
+  visibility: absolute !important;
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -67,8 +67,8 @@ div.column-header .mat-card-header {
   background:
     /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)),
     linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
-    /* Shadows */ radial-gradient(50% 0, farthest-side, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
-    radial-gradient(50% 100%, farthest-side, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+    /* Shadows */ radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
   background:
     /* Shadow covers */ linear-gradient(white 30%, rgba(255, 255, 255, 0)),
     linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -167,29 +167,37 @@ div.column-header .mat-card-header {
   cursor: pointer;
 }
 
-:host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous {
-  display: none !important;
-}
-
-:host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-next {
-  display: none !important;
-}
-
-:host ::ng-deep .pagination-hide-arrow .mat-paginator-range-actions {
-  display: flex !important;
-}
-
-:host ::ng-deep .show-only-range-label .mat-paginator-range-label {
-  display: block !important;
-  margin: 0 32px 0 24px;
-}
-
 :host ::ng-deep .mat-paginator-container {
   display: flex;
   min-height: 56px;
   align-items: center;
-  justify-content: flex-end;
   padding: 0 8px;
   flex-wrap: wrap-reverse;
   width: 100%;
+  position: relative;
+}
+
+:host ::ng-deep .mat-paginator-range-label {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  flex: none;
+  display: block !important;
+}
+
+:host ::ng-deep .mat-paginator-range-actions {
+  margin-left: auto;
+  display: flex !important;
+}
+
+:host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous,
+:host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-next {
+  visibility: hidden !important;
+}
+
+:host ::ng-deep .pagination-hide-arrow .mat-paginator-range-actions {
+  display: flex !important;
+  justify-content: flex-end;
+  width: auto;
 }

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -178,7 +178,7 @@ div.column-header .mat-card-header {
 }
 
 :host ::ng-deep .mat-paginator-range-label {
-  position: absolute;
+  position: static;
   left: 50%;
   transform: translateX(-50%);
   margin: 0;

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -176,5 +176,20 @@ div.column-header .mat-card-header {
 }
 
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-range-actions {
-  display: none !important;
+  display: flex !important;
+}
+
+:host ::ng-deep .show-only-range-label .mat-paginator-range-label {
+  display: block !important;
+  margin: 0 32px 0 24px;
+}
+
+:host ::ng-deep .mat-paginator-container {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 8px;
+  flex-wrap: wrap-reverse;
+  width: 100%;
 }

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -17,7 +17,9 @@
     [pageSize]="pageSize"
     [hidePageSize]="true"
     [pageSizeOptions]="[10, 20, 50]"
-    [class]="pageSize >= issueLength ? 'pagination-hide-arrow' : ''"
+    [class.pagination-hide-arrow]="pageSize >= issueLength"
+    [class.show-only-range-label]="true"
+    [length]="issueLength"
   ></mat-paginator>
 </div>
 


### PR DESCRIPTION
### Summary:

Fixes https://github.com/CATcher-org/WATcher/issues/470

Added and centralised the pagination range label at the bottom of each user for consistency purposes. Also reduced the coupling with the pagination arrows.

#### Type of change:

- ✨ New Feature/ Enhancement
- 🎨 Code Refactoring

### Changes Made:

- Add paginator container and range label to replace default implementations for flexible styling 
- Auto-hide navigation arrows when there is only 1 page of issues and PRs to show
- Refactor Gradient direction syntax (fixes warning of outdated syntax)

### Screenshots:

<img width="1022" height="521" alt="Screenshot_14" src="https://github.com/user-attachments/assets/b99e7601-59b2-4098-953c-ec65b730191b" />

### Proposed Commit Message:

```
Add pagination styling for card view consistency

There is no pagination range shown when the number of issues/pr cards 
is not more than the required amount of 20.

This change adds paginator components, ensuring consistent
appearance across all card view columns. It also refactors Gradient syntax 
that has been deprecated.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
